### PR TITLE
Upgraded Http4s dependency from 0.18.11 to 0.20.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,17 @@ First we create an interpreter, which requires an http4s client and
 a base url for consul:
 
 ```
+import scala.concurrent.ExecutionContext
 import cats.effect.IO
 import helm.http4s._
 import org.http4s.Uri.uri
-import org.http4s.client.blaze.Http1Client
+import org.http4s.client.blaze.BlazeClientBuilder
 
-val client = Http1Client[IO]().unsafeRunSync
+val ec = ExecutionContext.global
+implicit val contextShift = IO.contextShift(ec)
+// It's better to run everything inside of resource.use() where possible, but this makes for a simpler example
+val client = BlazeClientBuilder[IO](ec).resource.allocated.unsafeRunSync()._1
+
 val baseUrl = uri("http://127.0.0.1:8500")
 
 val interpreter = new Http4sConsulClient(baseUrl, client)

--- a/http4s/build.sbt
+++ b/http4s/build.sbt
@@ -1,6 +1,6 @@
 
 val http4sOrg = "org.http4s"
-val http4sVersion = "0.18.11"
+val http4sVersion = "0.20.0"
 val dockeritVersion = "0.9.8"
 
 enablePlugins(ScalaTestPlugin, ScalaCheckPlugin)
@@ -18,35 +18,37 @@ libraryDependencies ++= Seq(
 )
 
 (initialCommands in console) := """
-import helm._
-import http4s._
+import helm.http4s.Http4sConsulClient
 
 import cats.effect.IO
-import scala.concurrent.duration.{DurationInt,Duration}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.{DurationInt, Duration}
 
 import org.http4s.Uri
 import org.http4s.client.Client
-import org.http4s.client.blaze.{BlazeClientConfig, PooledHttp1Client}
+import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.headers.{AgentProduct, `User-Agent`}
 import org.http4s.util.threads
 import java.nio.channels.AsynchronousChannelGroup
 import java.util.concurrent.{Executors, ExecutorService}
 import javax.net.ssl.SSLContext
 
-def clientEC() = {
+val clientEC = {
   val maxThreads = math.max(4, (Runtime.getRuntime.availableProcessors * 1.5).ceil.toInt)
   val threadFactory = threads.threadFactory(name = (i => s"http4s-blaze-client-$i"), daemon = true)
-  Executors.newFixedThreadPool(maxThreads, threadFactory)
+  ExecutionContext.fromExecutor(Executors.newFixedThreadPool(maxThreads, threadFactory))
 }
 
-val config = BlazeClientConfig.defaultConfig.copy(
-  idleTimeout = 60.seconds,
-  requestTimeout = 3.seconds,
-  bufferSize = 8 * 1024,
-  userAgent = Some(`User-Agent`(AgentProduct("http4s-blaze", Some(org.http4s.BuildInfo.version))))
-)
+implicit val contextShift = IO.contextShift(clientEC)
 
-val http = PooledHttp1Client[IO](maxTotalConnections = 10, config = config)
+val http = {
+  BlazeClientBuilder[IO](clientEC)
+  .withMaxTotalConnections(10)
+  .withIdleTimeout(60.seconds)
+  .withBufferSize(8 * 1024)
+  .withUserAgent(`User-Agent`(AgentProduct("http4s-blaze", Some(org.http4s.BuildInfo.version))))
+  .resource.allocated.unsafeRunSync()._1
+}
+
 val c = new Http4sConsulClient(Uri.uri("http://localhost:8500"), http)
-
 """

--- a/http4s/build.sbt
+++ b/http4s/build.sbt
@@ -1,6 +1,6 @@
 
 val http4sOrg = "org.http4s"
-val http4sVersion = "0.20.0"
+val http4sVersion = "0.20.6"
 val dockeritVersion = "0.9.8"
 
 enablePlugins(ScalaTestPlugin, ScalaCheckPlugin)

--- a/http4s/src/test/scala/Http4sConsulTests.scala
+++ b/http4s/src/test/scala/Http4sConsulTests.scala
@@ -2,8 +2,7 @@ package helm
 package http4s
 
 import cats.~>
-import cats.data.Kleisli
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import fs2.{Chunk, Stream}
 import org.http4s.{EntityBody, Header, Headers, Request, Response, Status, Uri}
 import org.http4s.client._
@@ -235,8 +234,7 @@ object Http4sConsulTests {
   }
 
   def constantResponseClient(response: Response[IO]): Client[IO] = {
-    val dispResponse = DisposableResponse(response, IO.unit)
-    Client(Kleisli{req => IO.pure(dispResponse)}, IO.unit)
+    Client(req => Resource.liftF(IO.pure(response)))
   }
 
   def body(s: String): EntityBody[IO] =


### PR DESCRIPTION
Also removed setting of Connection: keep-alive header in Http4sConsulClient because that's the default behavior anyway and so I added it to no effect.

In Http4s < v0.20.0, connection re-use doesn't work properly when the response uses `Transfer-Encoding: chunked` -- the connection is always closed once the response is fully read. Consul appears to chunk the response whenever the response length is over something like 2KB.

The http4s commit that fixed the bug I'm referring to is https://github.com/http4s/http4s/commit/95ad428488381750cb7e9e30f1fa4811a16af90e